### PR TITLE
Fix controller statistics typo

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2655,7 +2655,7 @@ def _get_controller_statistics_dict(
         "nak": statistics.nak,
         "can": statistics.can,
         "timeout_ack": statistics.timeout_ack,
-        "timout_response": statistics.timeout_response,
+        "timeout_response": statistics.timeout_response,
         "timeout_callback": statistics.timeout_callback,
     }
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -4879,7 +4879,7 @@ async def test_subscribe_controller_statistics(
         "nak": 0,
         "can": 0,
         "timeout_ack": 0,
-        "timout_response": 0,
+        "timeout_response": 0,
         "timeout_callback": 0,
     }
 
@@ -4914,7 +4914,7 @@ async def test_subscribe_controller_statistics(
         "nak": 1,
         "can": 1,
         "timeout_ack": 1,
-        "timout_response": 1,
+        "timeout_response": 1,
         "timeout_callback": 1,
     }
 


### PR DESCRIPTION
## Summary
- fix typo in controller statistics dictionary `timout_response` -> `timeout_response`
- update Z-Wave JS tests

## Testing
- `pytest tests/components/zwave_js -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68474ec4d138832c813bf5cc6fa8c350